### PR TITLE
refactor the driver and stop attempting to read light feedback

### DIFF
--- a/src/BowtechDriver.cpp
+++ b/src/BowtechDriver.cpp
@@ -30,7 +30,6 @@ namespace ledlamp_bowtech {
 		generateCommand(command, new_address, current_address, data);
 
 		this->writePacket(data, BOWTECH_COMMAND_SIZE + cmd_label.size());
-		readMsg();
 
 		delete[] data;
 	}
@@ -96,7 +95,6 @@ namespace ledlamp_bowtech {
 		generateCommand(command, value, address, data);
 
 		this->writePacket(data, BOWTECH_COMMAND_SIZE + cmd_label.size());
-		readMsg();
 
 		delete[] data;
 	}
@@ -116,7 +114,6 @@ namespace ledlamp_bowtech {
 
 
 		this->writePacket(data, BOWTECH_COMMAND_SIZE + cmd_label.size());
-		readMsg();
 
 		delete[] data;
 	}
@@ -143,13 +140,6 @@ namespace ledlamp_bowtech {
 	uint8_t BowtechDriver::checksum(uint8_t byte1, uint8_t byte2, uint8_t byte3)
 	{
 		return (byte1^byte2)^byte3;
-	}
-
-	void BowtechDriver::readMsg()
-	{
-		uint8_t* reply = new uint8_t[BOWTECH_MAX_PACKET_SIZE];
-		int packet_size = iodrivers_base::Driver::readPacket(reply, BOWTECH_MAX_PACKET_SIZE,50);
-		delete[] reply;
 	}
 
 	void BowtechDriver::generateCommand(uint8_t command, uint8_t value, uint8_t address, uint8_t *data)

--- a/src/BowtechDriver.cpp
+++ b/src/BowtechDriver.cpp
@@ -80,38 +80,34 @@ namespace ledlamp_bowtech {
 		delete[] data;
 	}
 
-	void BowtechDriver::setLightLevel(uint8_t value, uint8_t address)
+	void BowtechDriver::setLightLevel(float value, uint8_t address)
 	{
 		//if is a valid value, calculates the percentual value for the light level.
-		if (value > 100 || value ==0)
-			throw std::runtime_error("The light level must be a value between 1 and 100 - [1,100]");
-		else
-			value = (255*value)/100;
+		if (value < 0.0 || value > 1.0)
+			throw std::runtime_error("The light level must be a value between [0.0, 1.0]");
 
-
+		uint8_t light_value = 255 * value;
 		uint8_t* data = new uint8_t[BOWTECH_COMMAND_SIZE + cmd_label.size()];
 		uint8_t command = 0x28;
 
-		generateCommand(command, value, address, data);
+		generateCommand(command, light_value, address, data);
 
 		this->writePacket(data, BOWTECH_COMMAND_SIZE + cmd_label.size());
 
 		delete[] data;
 	}
 
-	void BowtechDriver::setPowerUpLightLevel(uint8_t value, uint8_t address)
+	void BowtechDriver::setPowerUpLightLevel(float value, uint8_t address)
 	{
 		//if is a valid value, calculates the percentual value for the light level.
-		if (value > 100 || value ==0)
-			throw std::runtime_error("The light level must be a value between 1 and 100 - [1,100]");
-		else
-			value = (255*value)/100;
+		if (value < 0.0 || value > 1.0)
+			throw std::runtime_error("The light level must be a value between [0.0, 1.0]");
 
+		uint8_t light_value = 255 * value;
 		uint8_t* data = new uint8_t[BOWTECH_COMMAND_SIZE + cmd_label.size()];
 		uint8_t command = 0x2A;
 
-		generateCommand(command, value, address, data);
-
+		generateCommand(command, light_value, address, data);
 
 		this->writePacket(data, BOWTECH_COMMAND_SIZE + cmd_label.size());
 

--- a/src/BowtechDriver.hpp
+++ b/src/BowtechDriver.hpp
@@ -45,7 +45,7 @@ namespace ledlamp_bowtech
 			 * Sets the light level of a specific lamp or sets the light
 			 * level for all lamps (BROADCAST_ADDRESS)
 			 * @param value - Desired light level. Should belong to the
-			 * 				  interval [1, 100]
+			 * 				  interval [0.0, 1.0]
 			 * @param address - Address of the lamp whose light level will
 			 * 					be changed. If address is equal to
 			 * 					BROADCAST_ADDRESS, then the light
@@ -53,12 +53,12 @@ namespace ledlamp_bowtech
 			 * 					changing the light level of a specific lamp,
 			 * 					its address must be set in this variable [1, 255].
 			 */
-			void setLightLevel(uint8_t value, uint8_t address=BROADCAST_ADDRESS);
+			void setLightLevel(float value, uint8_t address=BROADCAST_ADDRESS);
 
 			/**
 			 * Sets the default light level for when the lamp is powered up
 			 * @param value - Desired power up light level. Should belong to the
-			 * 				  interval [1, 100]
+			 * 				  interval [0.0, 1.0]
 			 * @param address - Address of the lamp whose power up light level will
 			 * 					be changed. If address is equal to
 			 * 					BROADCAST_ADDRESS, then the power up light
@@ -66,7 +66,7 @@ namespace ledlamp_bowtech
 			 * 					changing the power up light level of a specific lamp,
 			 * 					its address must be set in this variable [1, 255].
 			 */
-			void setPowerUpLightLevel(uint8_t value, uint8_t address=BROADCAST_ADDRESS);
+			void setPowerUpLightLevel(float value, uint8_t address=BROADCAST_ADDRESS);
 			/**
 			 * Sets the command label for the commands.
 			 * @param label - string that will be added at the begining of the command

--- a/test/test_Dummy.cpp
+++ b/test/test_Dummy.cpp
@@ -20,12 +20,10 @@ int main()
 	lamp.openSerial("/dev/ttyUSB0", 9600);
 	usleep(10000);
 
-//	lamp.setCmdLabel("<L>");
-
-	lamp.setPowerUpLightLevel(60);
+	lamp.setPowerUpLightLevel(0.6);
 	usleep(10000);
 
-	lamp.setLightLevel(40);
+	lamp.setLightLevel(0.4);
 	usleep(10000);
 
 


### PR DESCRIPTION
Diego: "They don't send any data when in a multi-drop configuration"

This is a fix to make the driver work.
